### PR TITLE
Language classification

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ tqdm==4.65.0
 PyDriller==2.5
 requests==2.31.0
 joblib~=1.2.0
+enry==0.1.1 ; python_version=="3.8"

--- a/simdev/util/lang_utils.py
+++ b/simdev/util/lang_utils.py
@@ -1,0 +1,32 @@
+from typing import Optional
+
+import enry
+
+
+def classify_language(name: str, contents: bytes, path: str) -> Optional[str]:
+    """
+    Classify programming languages used in the file
+    :param name: name of the file
+    :param contents: raw contents of the file
+    :param path: local path to the file
+    :return: classified programming language if any
+    """
+
+    # Check if file is suitable for programming languages classification:
+    # configurations, documentation, binaries etc. are skipped
+    if contents is None or \
+            enry.is_binary(contents) or \
+            enry.is_vendor(name) or \
+            enry.is_generated(name, contents) or \
+            (path is not None and
+             (enry.is_image(path) or
+              enry.is_configuration(path) or
+              enry.is_documentation(path) or
+              enry.is_dot_file(path))):
+        return
+
+    prog_language = enry.get_language(name, contents)
+    if len(prog_language) == 0:
+        return None
+    else:
+        return prog_language

--- a/tests/git_basics_test.py
+++ b/tests/git_basics_test.py
@@ -31,6 +31,7 @@ class GitBasicsTest(unittest.TestCase):
         extractor.extract()
         repo_info = extractor.dev_info['santi@mola.io'][TEST_LANGUAGES_REPO_URL]
         langs = repo_info['langs']
+
         self.assertEqual({'Go': 6}, dict(langs))
         repo_info = extractor.dev_info['bzz@apache.org'][TEST_LANGUAGES_REPO_URL]
         self.assertEqual(

--- a/tests/git_basics_test.py
+++ b/tests/git_basics_test.py
@@ -33,19 +33,10 @@ class GitBasicsTest(unittest.TestCase):
         langs = repo_info['langs']
         self.assertEqual({'Go': 6}, dict(langs))
         repo_info = extractor.dev_info['bzz@apache.org'][TEST_LANGUAGES_REPO_URL]
-        self.assertEqual({
-            "Go": 147,
-            "Shell": 1,
-            "Scala": 7,
-            "Java": 4,
-            "Makefile": 7,
-            "CSV": 6,
-            "Text": 2,
-            "Go Module": 5,
-            "Go Checksums": 4,
-            "C": 4,
-            "Python": 8
-        }, dict(repo_info['langs']))
+        self.assertEqual(
+            {"Go": 147, "Shell": 1, "Scala": 7, "Java": 4, "Makefile": 7, "CSV": 6,
+             "Text": 11, "C": 4, "Python": 8},
+            dict(repo_info['langs']))
 
     def test_commit_limit(self):
         extractor = RepoInfoExtractor(repo_urls=[TEST_REPO_URL], max_commit_count=1)

--- a/tests/git_basics_test.py
+++ b/tests/git_basics_test.py
@@ -6,9 +6,6 @@ from simdev.util.pipeline import PipelineCache
 # Sample read-only repository
 TEST_REPO_URL = "https://github.com/TheSeems/HseNotebooks"
 
-# Forked go-enry read-only repository URL for test on language classification
-TEST_LANGUAGES_REPO_URL = "https://github.com/TheSeems/go-enry"
-
 
 class GitBasicsTest(unittest.TestCase):
     def setUp(self):
@@ -25,19 +22,6 @@ class GitBasicsTest(unittest.TestCase):
         self.assertEqual(674, files['LICENSE']['added_lines'])
         self.assertEqual(0, files['LICENSE']['deleted_lines'])
         self.assertEqual(115, files['Alg_7_2020_tasks.ipynb']['deleted_lines'])
-
-    def test_public_repo_languages(self):
-        extractor = RepoInfoExtractor([TEST_LANGUAGES_REPO_URL])
-        extractor.extract()
-        repo_info = extractor.dev_info['santi@mola.io'][TEST_LANGUAGES_REPO_URL]
-        langs = repo_info['langs']
-
-        self.assertEqual({'Go': 6}, dict(langs))
-        repo_info = extractor.dev_info['bzz@apache.org'][TEST_LANGUAGES_REPO_URL]
-        self.assertEqual(
-            {"Go": 147, "Shell": 1, "Scala": 7, "Java": 4, "Makefile": 7, "CSV": 6,
-             "Text": 11, "C": 4, "Python": 8},
-            dict(repo_info['langs']))
 
     def test_commit_limit(self):
         extractor = RepoInfoExtractor(repo_urls=[TEST_REPO_URL], max_commit_count=1)

--- a/tests/git_basics_test.py
+++ b/tests/git_basics_test.py
@@ -6,6 +6,9 @@ from simdev.util.pipeline import PipelineCache
 # Sample read-only repository
 TEST_REPO_URL = "https://github.com/TheSeems/HseNotebooks"
 
+# Forked go-enry read-only repository URL for test on language classification
+TEST_LANGUAGES_REPO_URL = "https://github.com/TheSeems/go-enry"
+
 
 class GitBasicsTest(unittest.TestCase):
     def setUp(self):
@@ -22,6 +25,27 @@ class GitBasicsTest(unittest.TestCase):
         self.assertEqual(674, files['LICENSE']['added_lines'])
         self.assertEqual(0, files['LICENSE']['deleted_lines'])
         self.assertEqual(115, files['Alg_7_2020_tasks.ipynb']['deleted_lines'])
+
+    def test_public_repo_languages(self):
+        extractor = RepoInfoExtractor([TEST_LANGUAGES_REPO_URL])
+        extractor.extract()
+        repo_info = extractor.dev_info['santi@mola.io'][TEST_LANGUAGES_REPO_URL]
+        langs = repo_info['langs']
+        self.assertEqual({'Go': 6}, dict(langs))
+        repo_info = extractor.dev_info['bzz@apache.org'][TEST_LANGUAGES_REPO_URL]
+        self.assertEqual({
+            "Go": 147,
+            "Shell": 1,
+            "Scala": 7,
+            "Java": 4,
+            "Makefile": 7,
+            "CSV": 6,
+            "Text": 2,
+            "Go Module": 5,
+            "Go Checksums": 4,
+            "C": 4,
+            "Python": 8
+        }, dict(repo_info['langs']))
 
     def test_commit_limit(self):
         extractor = RepoInfoExtractor(repo_urls=[TEST_REPO_URL], max_commit_count=1)


### PR DESCRIPTION
Use enry (python bindings) to classify languages for files in commits at clone stage